### PR TITLE
Fix edge case where interface can get stuck unjoined

### DIFF
--- a/provides.py
+++ b/provides.py
@@ -1,13 +1,14 @@
 #!/usr/bin/python
 
 from charms.reactive import Endpoint
-from charms.reactive import when, when_not
+from charms.reactive import when_any, when_not
 from charms.reactive import set_state, remove_state
 
 
 class CNIPluginProvider(Endpoint):
 
-    @when('endpoint.{endpoint_name}.changed')
+    @when_any('endpoint.{endpoint_name}.joined',
+              'endpoint.{endpoint_name}.changed')
     def changed(self):
         ''' Set the connected state from the provides side of the relation. '''
         set_state(self.expand_name('{endpoint_name}.connected'))

--- a/requires.py
+++ b/requires.py
@@ -1,13 +1,14 @@
 #!/usr/bin/python
 
 from charms.reactive import Endpoint
-from charms.reactive import when, when_not
+from charms.reactive import when_any, when_not
 from charms.reactive import set_state, remove_state
 
 
 class CNIPluginClient(Endpoint):
 
-    @when('endpoint.{endpoint_name}.changed')
+    @when_any('endpoint.{endpoint_name}.joined',
+              'endpoint.{endpoint_name}.changed')
     def changed(self):
         ''' Indicate the relation is connected, and if the relation data is
         set it is also available. '''


### PR DESCRIPTION
There is apparently an edge case where the changed and broken handlers can get queued in a hook and fire in that order leading to no subsequent changed handlers being queued and the flags all being left cleared (and thus leading to stuck charms on either end). It's safer overall to include joined in the handler conditions so that even if something strange happens, it will sort itself out into the stable state.

Fixes [lp:1841259](https://bugs.launchpad.net/charm-flannel/+bug/1841259)