### PR TITLE
Add support for multiple CNI subordinates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: python
+python:
+  - "3.5"
+install:
+  - pip install tox-travis
+script:
+  - tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: python
 python:
   - "3.5"
+  - "3.6"
+  - "3.7"
 install:
   - pip install tox-travis
 script:

--- a/interface.yaml
+++ b/interface.yaml
@@ -2,3 +2,5 @@ name: kubernetes-cni
 summary: Interface for relating various CNI implementations
 version: 0
 maintainer: "Rye Terrell <rye.terrell@canonical.com>"
+ignore:
+- tests

--- a/interface.yaml
+++ b/interface.yaml
@@ -1,6 +1,6 @@
 name: kubernetes-cni
 summary: Interface for relating various CNI implementations
 version: 0
-maintainer: "Rye Terrell <rye.terrell@canonical.com>"
+maintainer: "George Kraft <george.kraft@canonical.com>"
 ignore:
 - tests

--- a/provides.py
+++ b/provides.py
@@ -53,6 +53,15 @@ class CNIPluginProvider(Endpoint):
         )
 
     def get_config(self, default=None):
+        ''' Get CNI config for one related application.
+
+        If default is specified, and there is a related application with a
+        matching name, then that application is chosen. Otherwise, the
+        application is chosen alphabetically.
+
+        Whichever application is chosen, that application's CNI config is
+        returned.
+        '''
         configs = self.get_configs()
         if default and default not in configs:
             msg = 'relation not found for default CNI %s, ignoring' % default
@@ -64,6 +73,21 @@ class CNIPluginProvider(Endpoint):
             return configs[sorted(configs)[0]]
 
     def get_configs(self):
+        ''' Get CNI configs for all related applications.
+
+        This returns a mapping of application names to CNI configs. Here's an
+        example return value:
+        {
+            'flannel': {
+                'cidr': '10.1.0.0/16',
+                'cni-conf-file': '10-flannel.conflist'
+            },
+            'calico': {
+                'cidr': '192.168.0.0/16',
+                'cni-conf-file': '10-calico.conflist'
+            }
+        }
+        '''
         return {
             relation.application_name: relation.joined_units.received_raw
             for relation in self.relations if relation.application_name

--- a/provides.py
+++ b/provides.py
@@ -1,5 +1,6 @@
 #!/usr/bin/python
 
+from charmhelpers.core import hookenv
 from charms.reactive import Endpoint
 from charms.reactive import when_any, when_not
 from charms.reactive import set_state, remove_state
@@ -7,13 +8,15 @@ from charms.reactive import set_state, remove_state
 
 class CNIPluginProvider(Endpoint):
 
-    @when_any('endpoint.{endpoint_name}.joined',
-              'endpoint.{endpoint_name}.changed')
+    @when_any('endpoint.{endpoint_name}.changed')
     def changed(self):
         ''' Set the connected state from the provides side of the relation. '''
         set_state(self.expand_name('{endpoint_name}.connected'))
         if self.config_available():
             set_state(self.expand_name('{endpoint_name}.available'))
+        else:
+            remove_state(self.expand_name('{endpoint_name}.available'))
+        remove_state(self.expand_name('{endpoint_name}.configured'))
         remove_state(self.expand_name('endpoint.{endpoint_name}.changed'))
 
     @when_not('endpoint.{endpoint_name}.joined')
@@ -34,11 +37,34 @@ class CNIPluginProvider(Endpoint):
 
     def config_available(self):
         ''' Ensures all config from the CNI plugin is available. '''
-        cidr = self.all_joined_units.received_raw['cidr']
-        if not cidr:
+        goal_state = hookenv.goal_state()
+        related_apps = [
+            name for name in goal_state['relations'][self.endpoint_name]
+            if '/' not in name
+        ]
+        if not related_apps:
             return False
-        return True
+        configs = self.get_configs()
+        return all(
+            'cidr' in config and 'cni-conf-file' in config
+            for config in [
+                configs.get(related_app, {}) for related_app in related_apps
+            ]
+        )
 
-    def get_config(self):
-        ''' Returns all config from the CNI plugin. '''
-        return self.all_joined_units.received_raw
+    def get_config(self, default=None):
+        configs = self.get_configs()
+        if default and default not in configs:
+            msg = 'relation not found for default CNI %s, ignoring' % default
+            hookenv.log(msg, level='WARN')
+            return self.get_config()
+        elif default:
+            return configs.get(default)
+        else:
+            return configs[sorted(configs)[0]]
+
+    def get_configs(self):
+        return {
+            relation.application_name: relation.joined_units.received_raw
+            for relation in self.relations if relation.application_name
+        }

--- a/requires.py
+++ b/requires.py
@@ -36,9 +36,10 @@ class CNIPluginClient(Endpoint):
         ''' Get the kubernetes configuration information. '''
         return self.all_joined_units.received_raw
 
-    def set_config(self, cidr):
+    def set_config(self, cidr, cni_conf_file):
         ''' Sets the CNI configuration information. '''
         for relation in self.relations:
             relation.to_publish_raw.update({
                 'cidr': cidr,
+                'cni-conf-file': cni_conf_file
             })

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,23 @@
+import sys
+from unittest.mock import MagicMock
+
+charmhelpers = MagicMock()
+sys.modules['charmhelpers'] = charmhelpers
+sys.modules['charmhelpers.core'] = charmhelpers.core
+sys.modules['charmhelpers.core.hookenv'] = charmhelpers.core.hookenv
+
+charms = MagicMock()
+sys.modules['charms'] = charms
+sys.modules['charms.reactive'] = charms.reactive
+
+
+class MockEndpoint(MagicMock):
+    @property
+    def endpoint_name(self):
+        return 'cni'
+
+    def expand_name(self, name):
+        return name.replace('{endpoint_name}', self.endpoint_name)
+
+
+charms.reactive.Endpoint = MockEndpoint

--- a/tests/test_provides.py
+++ b/tests/test_provides.py
@@ -1,0 +1,102 @@
+from unittest.mock import MagicMock
+import charmhelpers
+import charms
+
+import provides
+
+
+def test_set_config():
+    provider = provides.CNIPluginProvider()
+    provider.relations = [MagicMock(), MagicMock()]
+    provider.set_config(False, '/path/to/kubeconfig')
+    for relation in provider.relations:
+        relation.to_publish_raw.update.assert_called_once_with({
+            'is_master': False,
+            'kubeconfig_path': '/path/to/kubeconfig'
+        })
+    charms.reactive.set_state.assert_called_once_with(
+        'cni.configured'
+    )
+
+
+def test_get_configs():
+    provider = provides.CNIPluginProvider()
+    provider.relations = [MagicMock(), MagicMock()]
+    provider.relations[0].application_name = 'app0'
+    provider.relations[0].joined_units.received_raw = {
+        'cidr': '192.168.0.0/16'
+    }
+    provider.relations[1].application_name = None
+    config = provider.get_configs()
+    assert config == {'app0': {'cidr': '192.168.0.0/16'}}
+
+
+def test_get_config():
+    provider = provides.CNIPluginProvider()
+    provider.relations = [MagicMock(), MagicMock()]
+    provider.relations[0].application_name = 'app0'
+    provider.relations[0].joined_units.received_raw = {
+        'cidr': '192.168.0.0/24'
+    }
+    provider.relations[1].application_name = 'app1'
+    provider.relations[1].joined_units.received_raw = {
+        'cidr': '192.168.1.0/24'
+    }
+    assert provider.get_config() == {'cidr': '192.168.0.0/24'}
+    assert provider.get_config('app0') == {'cidr': '192.168.0.0/24'}
+    assert provider.get_config('app1') == {'cidr': '192.168.1.0/24'}
+
+
+def test_config_available():
+    provider = provides.CNIPluginProvider()
+    provider.relations = [MagicMock(), MagicMock()]
+    provider.relations[0].application_name = 'app0'
+    provider.relations[1].application_name = 'app1'
+
+    def set_base_data():
+        charmhelpers.core.hookenv.goal_state.return_value = {
+            'relations': {
+                'cni': {
+                    'app0': 'foo',
+                    'app1': 'foo',
+                }
+            }
+        }
+        provider.relations[0].joined_units.received_raw = {
+            'cidr': '192.168.0.0/24',
+            'cni-conf-file': '10-app0.conflist'
+        }
+        provider.relations[1].joined_units.received_raw = {
+            'cidr': '192.168.1.0/24',
+            'cni-conf-file': '10-app1.conflist'
+        }
+
+    # if there are no related apps, then config is not available yet
+    set_base_data()
+    goal_state = charmhelpers.core.hookenv.goal_state()
+    goal_state['relations']['cni'] = {}
+    assert not provider.config_available()
+
+    # if goal_state shows an app that's missing from relations, then config
+    # is not available yet
+    set_base_data()
+    goal_state = charmhelpers.core.hookenv.goal_state()
+    goal_state['relations']['cni']['app2'] = 'foo'
+    assert not provider.config_available()
+
+    # if cidr is missing from any related app, then config is not available
+    for i in range(2):
+        set_base_data()
+        del provider.relations[i].joined_units.received_raw['cidr']
+        assert not provider.config_available()
+
+    # if cni-conf-file is missing from any related app, then config is not
+    # available
+    for i in range(2):
+        set_base_data()
+        del provider.relations[i].joined_units.received_raw['cni-conf-file']
+        assert not provider.config_available()
+
+    # otherwise, config is available
+    set_base_data()
+    assert provider.config_available()

--- a/tests/test_requires.py
+++ b/tests/test_requires.py
@@ -1,0 +1,24 @@
+from unittest.mock import MagicMock
+
+import requires
+
+
+def test_get_config():
+    client = requires.CNIPluginClient()
+    config = {
+        'is_master': False,
+        'kubeconfig_path': '/path/to/kubeconfig'
+    }
+    client.all_joined_units.received_raw = config
+    assert client.get_config() == config
+
+
+def test_set_config():
+    client = requires.CNIPluginClient()
+    client.relations = [MagicMock(), MagicMock()]
+    client.set_config('192.168.0.0/24', '10-test.conflist')
+    for relation in client.relations:
+        relation.to_publish_raw.update.assert_called_once_with({
+            'cidr': '192.168.0.0/24',
+            'cni-conf-file': '10-test.conflist'
+        })

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,21 @@
+[tox]
+skipsdist = True
+envlist = lint,py3
+
+[tox:travis]
+3.5: lint,py3
+
+[testenv]
+basepython = python3
+setenv =
+    PYTHONPATH={toxinidir}:{toxinidir}/lib
+deps =
+    pyyaml
+    pytest
+    flake8
+    ipdb
+commands = pytest --tb native -s {posargs}
+
+[testenv:lint]
+envdir = {toxworkdir}/py3
+commands = flake8 {toxinidir}

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,8 @@ envlist = lint,py3
 
 [tox:travis]
 3.5: lint,py3
+3.6: lint,py3
+3.7: lint,py3
 
 [testenv]
 basepython = python3


### PR DESCRIPTION
Partial fix for https://bugs.launchpad.net/charm-kubernetes-master/+bug/1861709

Please be careful merging this, as it's mutually dependent on the work of other PRs in that issue. They will need to be merged together.

This changes interface-kubernetes-cni mainly in two ways:
1. On `endpoint.{endpoint_name}.changed`, clear the `{endpoint_name}.configured` flag. This signals to the principal charm that it needs to re-send configuration as new subordinate relations are established.
2. Replace `get_config()` with `get_configs()` and `get_config(default=...)` to accommodate configs coming from multiple subordinates.