### PR TITLE
Fix hook error during cni-relation-departed hook

### DIFF
--- a/provides.py
+++ b/provides.py
@@ -2,7 +2,7 @@
 
 from charmhelpers.core import hookenv
 from charms.reactive import Endpoint
-from charms.reactive import toggle_flag, is_flag, clear_flag, set_flag
+from charms.reactive import toggle_flag, is_flag_set, clear_flag, set_flag
 
 
 class CNIPluginProvider(Endpoint):
@@ -11,7 +11,7 @@ class CNIPluginProvider(Endpoint):
                     self.is_joined)
         toggle_flag(self.expand_name('{endpoint_name}.available'),
                     self.config_available())
-        if is_flag(self.expand_name('endpoint.{endpoint_name}.changed')):
+        if is_flag_set(self.expand_name('endpoint.{endpoint_name}.changed')):
             clear_flag(self.expand_name('{endpoint_name}.configured'))
             clear_flag(self.expand_name('endpoint.{endpoint_name}.changed'))
 

--- a/provides.py
+++ b/provides.py
@@ -2,7 +2,7 @@
 
 from charmhelpers.core import hookenv
 from charms.reactive import Endpoint
-from charms.reactive import toggle_flag, clear_flag, set_flag
+from charms.reactive import toggle_flag, is_flag, clear_flag, set_flag
 
 
 class CNIPluginProvider(Endpoint):
@@ -11,7 +11,9 @@ class CNIPluginProvider(Endpoint):
                     self.is_joined)
         toggle_flag(self.expand_name('{endpoint_name}.available'),
                     self.config_available())
-        clear_flag(self.expand_name('{endpoint_name}.configured'))
+        if is_flag(self.expand_name('endpoint.{endpoint_name}.changed')):
+            clear_flag(self.expand_name('{endpoint_name}.configured'))
+            clear_flag(self.expand_name('endpoint.{endpoint_name}.changed'))
 
     def set_config(self, is_master, kubeconfig_path):
         ''' Relays a dict of kubernetes configuration information. '''

--- a/provides.py
+++ b/provides.py
@@ -2,29 +2,16 @@
 
 from charmhelpers.core import hookenv
 from charms.reactive import Endpoint
-from charms.reactive import when_any, when_not
-from charms.reactive import set_state, remove_state
+from charms.reactive import toggle_flag, clear_flag, set_flag
 
 
 class CNIPluginProvider(Endpoint):
-
-    @when_any('endpoint.{endpoint_name}.changed')
-    def changed(self):
-        ''' Set the connected state from the provides side of the relation. '''
-        set_state(self.expand_name('{endpoint_name}.connected'))
-        if self.config_available():
-            set_state(self.expand_name('{endpoint_name}.available'))
-        else:
-            remove_state(self.expand_name('{endpoint_name}.available'))
-        remove_state(self.expand_name('{endpoint_name}.configured'))
-        remove_state(self.expand_name('endpoint.{endpoint_name}.changed'))
-
-    @when_not('endpoint.{endpoint_name}.joined')
-    def broken_or_departed(self):
-        '''Remove connected state from the provides side of the relation. '''
-        remove_state(self.expand_name('{endpoint_name}.connected'))
-        remove_state(self.expand_name('{endpoint_name}.available'))
-        remove_state(self.expand_name('{endpoint_name}.configured'))
+    def manage_flags(self):
+        toggle_flag(self.expand_name('{endpoint_name}.connected'),
+                    self.is_joined)
+        toggle_flag(self.expand_name('{endpoint_name}.available'),
+                    self.config_available())
+        clear_flag(self.expand_name('{endpoint_name}.configured'))
 
     def set_config(self, is_master, kubeconfig_path):
         ''' Relays a dict of kubernetes configuration information. '''
@@ -33,7 +20,7 @@ class CNIPluginProvider(Endpoint):
                 'is_master': is_master,
                 'kubeconfig_path': kubeconfig_path
             })
-        set_state(self.expand_name('{endpoint_name}.configured'))
+        set_flag(self.expand_name('{endpoint_name}.configured'))
 
     def config_available(self):
         ''' Ensures all config from the CNI plugin is available. '''
@@ -63,14 +50,16 @@ class CNIPluginProvider(Endpoint):
         returned.
         '''
         configs = self.get_configs()
-        if default and default not in configs:
+        if not configs:
+            return {}
+        elif default and default not in configs:
             msg = 'relation not found for default CNI %s, ignoring' % default
             hookenv.log(msg, level='WARN')
             return self.get_config()
         elif default:
-            return configs.get(default)
+            return configs.get(default, {})
         else:
-            return configs[sorted(configs)[0]]
+            return configs.get(sorted(configs)[0], {})
 
     def get_configs(self):
         ''' Get CNI configs for all related applications.

--- a/tests/test_provides.py
+++ b/tests/test_provides.py
@@ -14,7 +14,7 @@ def test_set_config():
             'is_master': False,
             'kubeconfig_path': '/path/to/kubeconfig'
         })
-    charms.reactive.set_state.assert_called_once_with(
+    charms.reactive.set_flag.assert_called_once_with(
         'cni.configured'
     )
 


### PR DESCRIPTION
https://bugs.launchpad.net/charm-kubernetes-master/+bug/1861709

Proposed fix for the following hook error during `cni-relation-departed` on kubernetes-worker:

```
unit-kubernetes-worker-0: 10:41:04 ERROR unit.kubernetes-worker/0.juju-log cni:15: Hook error:
Traceback (most recent call last):
  File "/var/lib/juju/agents/unit-kubernetes-worker-0/.venv/lib/python3.6/site-packages/charms/reactive/__init__.py", line 74, in main
    bus.dispatch(restricted=restricted_mode)
  File "/var/lib/juju/agents/unit-kubernetes-worker-0/.venv/lib/python3.6/site-packages/charms/reactive/bus.py", line 390, in dispatch
    _invoke(other_handlers)
  File "/var/lib/juju/agents/unit-kubernetes-worker-0/.venv/lib/python3.6/site-packages/charms/reactive/bus.py", line 359, in _invoke
    handler.invoke()
  File "/var/lib/juju/agents/unit-kubernetes-worker-0/.venv/lib/python3.6/site-packages/charms/reactive/bus.py", line 181, in invoke
    self._action(*args)
  File "/var/lib/juju/agents/unit-kubernetes-worker-0/charm/reactive/kubernetes_worker.py", line 530, in watch_for_changes
    cluster_cidr = cni.get_config().get('cidr')
  File "/var/lib/juju/agents/unit-kubernetes-worker-0/charm/hooks/relations/kubernetes-cni/provides.py", line 73, in get_config
    return configs[sorted(configs)[0]]
IndexError: list index out of range
unit-kubernetes-worker-0: 10:41:04 ERROR juju.worker.uniter.operation hook "cni-relation-departed" failed: exit status 1
```

Looks like a race condition where [watch_for_changes](https://github.com/charmed-kubernetes/charm-kubernetes-worker/blob/master/reactive/kubernetes_worker.py#L519) ran before [broken_or_departed](https://github.com/juju-solutions/interface-kubernetes-cni/blob/master/provides.py#L23). This PR should fix that by replacing the `broken_or_departed` handler with a `manage_flags` method on the interface, which is guaranteed to run before handlers.

This is completely untested. I will work on testing it now.