### PR TITLE
fix goal_state handling when no cni relations are present

### DIFF
--- a/provides.py
+++ b/provides.py
@@ -28,8 +28,8 @@ class CNIPluginProvider(Endpoint):
         ''' Ensures all config from the CNI plugin is available. '''
         goal_state = hookenv.goal_state()
         related_apps = [
-            name for name in goal_state['relations'][self.endpoint_name]
-            if '/' not in name
+            app for app in goal_state.get('relations', {}).get(self.endpoint_name, '')
+            if '/' not in app
         ]
         if not related_apps:
             return False

--- a/tests/test_provides.py
+++ b/tests/test_provides.py
@@ -53,6 +53,9 @@ def test_config_available():
     provider.relations[0].application_name = 'app0'
     provider.relations[1].application_name = 'app1'
 
+    def set_no_data():
+        charmhelpers.core.hookenv.goal_state.return_value = {}
+
     def set_base_data():
         charmhelpers.core.hookenv.goal_state.return_value = {
             'relations': {
@@ -71,7 +74,12 @@ def test_config_available():
             'cni-conf-file': '10-app1.conflist'
         }
 
-    # if there are no related apps, then config is not available yet
+    # if there are no relations, then config is not available yet
+    set_no_data()
+    goal_state = charmhelpers.core.hookenv.goal_state()
+    assert not provider.config_available()
+
+    # if there are no related cni apps, then config is not available yet
     set_base_data()
     goal_state = charmhelpers.core.hookenv.goal_state()
     goal_state['relations']['cni'] = {}

--- a/tests/test_provides.py
+++ b/tests/test_provides.py
@@ -53,9 +53,6 @@ def test_config_available():
     provider.relations[0].application_name = 'app0'
     provider.relations[1].application_name = 'app1'
 
-    def set_no_data():
-        charmhelpers.core.hookenv.goal_state.return_value = {}
-
     def set_base_data():
         charmhelpers.core.hookenv.goal_state.return_value = {
             'relations': {
@@ -74,9 +71,10 @@ def test_config_available():
             'cni-conf-file': '10-app1.conflist'
         }
 
-    # if there are no relations, then config is not available yet
-    set_no_data()
+    # if there are no cni relations, then config is not available yet
+    set_base_data()
     goal_state = charmhelpers.core.hookenv.goal_state()
+    goal_state['relations'] = {}
     assert not provider.config_available()
 
     # if there are no related cni apps, then config is not available yet

--- a/tox.ini
+++ b/tox.ini
@@ -20,4 +20,4 @@ commands = pytest --tb native -s {posargs}
 
 [testenv:lint]
 envdir = {toxworkdir}/py3
-commands = flake8 {toxinidir}
+commands = flake8 --max-line-length=88 {toxinidir}


### PR DESCRIPTION
https://bugs.launchpad.net/charm-kubernetes-master/+bug/1870809

When `kubernetes-[master|worker]` is deployed by itself, `manage_flags` will fail when trying to reference `goal_state()['relations']['cni']`:

```python
Traceback (most recent call last):
  File "/var/lib/juju/agents/unit-kwb-0/.venv/lib/python3.6/site-packages/charms/reactive/__init__.py", line 73, in main
    hookenv._run_atstart()
  File "/var/lib/juju/agents/unit-kwb-0/.venv/lib/python3.6/site-packages/charmhelpers/core/hookenv.py", line 1312, in _run_atstart
    callback(*args, **kwargs)
  File "/var/lib/juju/agents/unit-kwb-0/.venv/lib/python3.6/site-packages/charms/reactive/endpoints.py", line 132, in _startup
    endpoint._manage_flags()
  File "/var/lib/juju/agents/unit-kwb-0/.venv/lib/python3.6/site-packages/charms/reactive/endpoints.py", line 251, in _manage_flags
    self.manage_flags()
  File "/var/lib/juju/agents/unit-kwb-0/charm/hooks/relations/kubernetes-cni/provides.py", line 13, in manage_flags
    self.config_available())
  File "/var/lib/juju/agents/unit-kwb-0/charm/hooks/relations/kubernetes-cni/provides.py", line 31, in config_available
    name for name in goal_state['relations'][self.endpoint_name]
KeyError: 'cni'
```

This PR handles the case where there are no cni relations and adds a provider test.  It also adjusts our line-length allowance in `tox.ini` to our team default (88 chars). I can assure you, this was **not** because the PR went out to 87 characters...

I tested a local build of both k8s-master and -worker with this PR, and both deploy as expected.