### PR TITLE
Add kubeconfig_changed notification, remove kubeconfig_path

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,0 +1,24 @@
+name: Test Suite for K8s Service Interface
+
+on:
+  - pull_request
+
+jobs:
+  lint-and-unit-tests:
+    name: Lint & Unit tests
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python: [3.6, 3.7, 3.8, 3.9]
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v2
+    - name: Setup Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python }}
+    - name: Install Tox
+      run: pip install tox
+    - name: Run lint & unit tests
+      run: tox
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 .DS_Store
+.tox
+__pycache__
+*.pyc

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-language: python
-python:
-  - "3.5"
-  - "3.6"
-  - "3.7"
-install:
-  - pip install tox-travis
-script:
-  - tox

--- a/provides.py
+++ b/provides.py
@@ -9,41 +9,38 @@ from charms.reactive import toggle_flag, is_flag_set, clear_flag, set_flag
 
 class CNIPluginProvider(Endpoint):
     def manage_flags(self):
-        toggle_flag(self.expand_name('{endpoint_name}.connected'),
-                    self.is_joined)
-        toggle_flag(self.expand_name('{endpoint_name}.available'),
-                    self.config_available())
-        if is_flag_set(self.expand_name('endpoint.{endpoint_name}.changed')):
-            clear_flag(self.expand_name('{endpoint_name}.configured'))
-            clear_flag(self.expand_name('endpoint.{endpoint_name}.changed'))
+        toggle_flag(self.expand_name("{endpoint_name}.connected"), self.is_joined)
+        toggle_flag(
+            self.expand_name("{endpoint_name}.available"), self.config_available()
+        )
+        if is_flag_set(self.expand_name("endpoint.{endpoint_name}.changed")):
+            clear_flag(self.expand_name("{endpoint_name}.configured"))
+            clear_flag(self.expand_name("endpoint.{endpoint_name}.changed"))
 
     def set_config(self, is_master):
-        ''' Relays a dict of kubernetes configuration information. '''
+        """Relays a dict of kubernetes configuration information."""
         for relation in self.relations:
-            relation.to_publish_raw.update({
-                'is_master': is_master
-            })
-        set_flag(self.expand_name('{endpoint_name}.configured'))
+            relation.to_publish_raw.update({"is_master": is_master})
+        set_flag(self.expand_name("{endpoint_name}.configured"))
 
     def config_available(self):
-        ''' Ensures all config from the CNI plugin is available. '''
+        """Ensures all config from the CNI plugin is available."""
         goal_state = hookenv.goal_state()
         related_apps = [
-            app for app in goal_state.get('relations', {}).get(self.endpoint_name, '')
-            if '/' not in app
+            app
+            for app in goal_state.get("relations", {}).get(self.endpoint_name, "")
+            if "/" not in app
         ]
         if not related_apps:
             return False
         configs = self.get_configs()
         return all(
-            'cidr' in config and 'cni-conf-file' in config
-            for config in [
-                configs.get(related_app, {}) for related_app in related_apps
-            ]
+            "cidr" in config and "cni-conf-file" in config
+            for config in [configs.get(related_app, {}) for related_app in related_apps]
         )
 
     def get_config(self, default=None):
-        ''' Get CNI config for one related application.
+        """Get CNI config for one related application.
 
         If default is specified, and there is a related application with a
         matching name, then that application is chosen. Otherwise, the
@@ -51,13 +48,13 @@ class CNIPluginProvider(Endpoint):
 
         Whichever application is chosen, that application's CNI config is
         returned.
-        '''
+        """
         configs = self.get_configs()
         if not configs:
             return {}
         elif default and default not in configs:
-            msg = 'relation not found for default CNI %s, ignoring' % default
-            hookenv.log(msg, level='WARN')
+            msg = "relation not found for default CNI %s, ignoring" % default
+            hookenv.log(msg, level="WARN")
             return self.get_config()
         elif default:
             return configs.get(default, {})
@@ -65,7 +62,7 @@ class CNIPluginProvider(Endpoint):
             return configs.get(sorted(configs)[0], {})
 
     def get_configs(self):
-        ''' Get CNI configs for all related applications.
+        """Get CNI configs for all related applications.
 
         This returns a mapping of application names to CNI configs. Here's an
         example return value:
@@ -79,15 +76,14 @@ class CNIPluginProvider(Endpoint):
                 'cni-conf-file': '10-calico.conflist'
             }
         }
-        '''
+        """
         return {
             relation.application_name: relation.joined_units.received_raw
-            for relation in self.relations if relation.application_name
+            for relation in self.relations
+            if relation.application_name
         }
 
     def notify_kubeconfig_changed(self):
         kubeconfig_hash = file_hash(kubeclientconfig_path)
         for relation in self.relations:
-            relation.to_publish_raw.update({
-                'kubeconfig-hash': kubeconfig_hash
-            })
+            relation.to_publish_raw.update({"kubeconfig-hash": kubeconfig_hash})

--- a/requires.py
+++ b/requires.py
@@ -1,11 +1,22 @@
 #!/usr/bin/python
 
+from charmhelpers.core import unitdata
 from charms.reactive import Endpoint
 from charms.reactive import when_any, when_not
 from charms.reactive import set_state, remove_state
 
+db = unitdata.kv()
+
 
 class CNIPluginClient(Endpoint):
+    def manage_flags(self):
+        kubeconfig_hash = self.get_config().get('kubeconfig-hash')
+        kubeconfig_hash_key = self.expand_name(
+            '{endpoint_name}.kubeconfig-hash'
+        )
+        if kubeconfig_hash != db.get(kubeconfig_hash_key):
+            set_state(self.expand_name('{endpoint_name}.kubeconfig-changed'))
+            db.set(kubeconfig_hash_key, kubeconfig_hash)
 
     @when_any('endpoint.{endpoint_name}.joined',
               'endpoint.{endpoint_name}.changed')

--- a/requires.py
+++ b/requires.py
@@ -12,8 +12,10 @@ class CNIPluginClient(Endpoint):
     def manage_flags(self):
         kubeconfig_hash = self.get_config().get("kubeconfig-hash")
         kubeconfig_hash_key = self.expand_name("{endpoint_name}.kubeconfig-hash")
+        if kubeconfig_hash:
+            set_state(self.expand_name("{endpoint_name}.kubeconfig.available"))
         if kubeconfig_hash != db.get(kubeconfig_hash_key):
-            set_state(self.expand_name("{endpoint_name}.kubeconfig-changed"))
+            set_state(self.expand_name("{endpoint_name}.kubeconfig.changed"))
             db.set(kubeconfig_hash_key, kubeconfig_hash)
 
     @when_any("endpoint.{endpoint_name}.joined", "endpoint.{endpoint_name}.changed")

--- a/requires.py
+++ b/requires.py
@@ -10,47 +10,43 @@ db = unitdata.kv()
 
 class CNIPluginClient(Endpoint):
     def manage_flags(self):
-        kubeconfig_hash = self.get_config().get('kubeconfig-hash')
-        kubeconfig_hash_key = self.expand_name(
-            '{endpoint_name}.kubeconfig-hash'
-        )
+        kubeconfig_hash = self.get_config().get("kubeconfig-hash")
+        kubeconfig_hash_key = self.expand_name("{endpoint_name}.kubeconfig-hash")
         if kubeconfig_hash != db.get(kubeconfig_hash_key):
-            set_state(self.expand_name('{endpoint_name}.kubeconfig-changed'))
+            set_state(self.expand_name("{endpoint_name}.kubeconfig-changed"))
             db.set(kubeconfig_hash_key, kubeconfig_hash)
 
-    @when_any('endpoint.{endpoint_name}.joined',
-              'endpoint.{endpoint_name}.changed')
+    @when_any("endpoint.{endpoint_name}.joined", "endpoint.{endpoint_name}.changed")
     def changed(self):
-        ''' Indicate the relation is connected, and if the relation data is
-        set it is also available. '''
-        set_state(self.expand_name('{endpoint_name}.connected'))
+        """Indicate the relation is connected, and if the relation data is
+        set it is also available."""
+        set_state(self.expand_name("{endpoint_name}.connected"))
         config = self.get_config()
-        if config['is_master'] == 'True':
-            set_state(self.expand_name('{endpoint_name}.is-master'))
-            set_state(self.expand_name('{endpoint_name}.configured'))
-        elif config['is_master'] == 'False':
-            set_state(self.expand_name('{endpoint_name}.is-worker'))
-            set_state(self.expand_name('{endpoint_name}.configured'))
+        if config["is_master"] == "True":
+            set_state(self.expand_name("{endpoint_name}.is-master"))
+            set_state(self.expand_name("{endpoint_name}.configured"))
+        elif config["is_master"] == "False":
+            set_state(self.expand_name("{endpoint_name}.is-worker"))
+            set_state(self.expand_name("{endpoint_name}.configured"))
         else:
-            remove_state(self.expand_name('{endpoint_name}.configured'))
-        remove_state(self.expand_name('endpoint.{endpoint_name}.changed'))
+            remove_state(self.expand_name("{endpoint_name}.configured"))
+        remove_state(self.expand_name("endpoint.{endpoint_name}.changed"))
 
-    @when_not('endpoint.{endpoint_name}.joined')
+    @when_not("endpoint.{endpoint_name}.joined")
     def broken(self):
-        ''' Indicate the relation is no longer available and not connected. '''
-        remove_state(self.expand_name('{endpoint_name}.connected'))
-        remove_state(self.expand_name('{endpoint_name}.is-master'))
-        remove_state(self.expand_name('{endpoint_name}.is-worker'))
-        remove_state(self.expand_name('{endpoint_name}.configured'))
+        """Indicate the relation is no longer available and not connected."""
+        remove_state(self.expand_name("{endpoint_name}.connected"))
+        remove_state(self.expand_name("{endpoint_name}.is-master"))
+        remove_state(self.expand_name("{endpoint_name}.is-worker"))
+        remove_state(self.expand_name("{endpoint_name}.configured"))
 
     def get_config(self):
-        ''' Get the kubernetes configuration information. '''
+        """Get the kubernetes configuration information."""
         return self.all_joined_units.received_raw
 
     def set_config(self, cidr, cni_conf_file):
-        ''' Sets the CNI configuration information. '''
+        """Sets the CNI configuration information."""
         for relation in self.relations:
-            relation.to_publish_raw.update({
-                'cidr': cidr,
-                'cni-conf-file': cni_conf_file
-            })
+            relation.to_publish_raw.update(
+                {"cidr": cidr, "cni-conf-file": cni_conf_file}
+            )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,23 +1,4 @@
-import sys
-from unittest.mock import MagicMock
-
-charmhelpers = MagicMock()
-sys.modules['charmhelpers'] = charmhelpers
-sys.modules['charmhelpers.core'] = charmhelpers.core
-sys.modules['charmhelpers.core.hookenv'] = charmhelpers.core.hookenv
-
-charms = MagicMock()
-sys.modules['charms'] = charms
-sys.modules['charms.reactive'] = charms.reactive
+import charms.unit_test
 
 
-class MockEndpoint(MagicMock):
-    @property
-    def endpoint_name(self):
-        return 'cni'
-
-    def expand_name(self, name):
-        return name.replace('{endpoint_name}', self.endpoint_name)
-
-
-charms.reactive.Endpoint = MockEndpoint
+charms.unit_test.patch_reactive()

--- a/tests/test_provides.py
+++ b/tests/test_provides.py
@@ -11,8 +11,7 @@ def test_set_config():
     provider.set_config(False, '/path/to/kubeconfig')
     for relation in provider.relations:
         relation.to_publish_raw.update.assert_called_once_with({
-            'is_master': False,
-            'kubeconfig_path': '/path/to/kubeconfig'
+            'is_master': False
         })
     charms.reactive.set_flag.assert_called_once_with(
         'cni.configured'

--- a/tests/test_provides.py
+++ b/tests/test_provides.py
@@ -1,105 +1,92 @@
-from unittest.mock import MagicMock
 import charmhelpers
-import charms
+from charms.reactive import is_flag_set
 
 import provides
 
 
 def test_set_config():
-    provider = provides.CNIPluginProvider()
-    provider.relations = [MagicMock(), MagicMock()]
-    provider.set_config(False, '/path/to/kubeconfig')
-    for relation in provider.relations:
-        relation.to_publish_raw.update.assert_called_once_with({
-            'is_master': False
-        })
-    charms.reactive.set_flag.assert_called_once_with(
-        'cni.configured'
-    )
+    provider = provides.CNIPluginProvider("cni", [1, 2])
+    provider.set_config(False)
+    assert [r.to_publish_raw for r in provider.relations] == [
+        {"is_master": False},
+        {"is_master": False},
+    ]
+    assert is_flag_set("cni.configured")
 
 
 def test_get_configs():
-    provider = provides.CNIPluginProvider()
-    provider.relations = [MagicMock(), MagicMock()]
-    provider.relations[0].application_name = 'app0'
-    provider.relations[0].joined_units.received_raw = {
-        'cidr': '192.168.0.0/16'
-    }
+    provider = provides.CNIPluginProvider("cni", [1, 2])
+    provider.relations[0].application_name = "app0"
+    provider.relations[0].joined_units.received_raw = {"cidr": "192.168.0.0/16"}
     provider.relations[1].application_name = None
     config = provider.get_configs()
-    assert config == {'app0': {'cidr': '192.168.0.0/16'}}
+    assert config == {"app0": {"cidr": "192.168.0.0/16"}}
 
 
 def test_get_config():
-    provider = provides.CNIPluginProvider()
-    provider.relations = [MagicMock(), MagicMock()]
-    provider.relations[0].application_name = 'app0'
-    provider.relations[0].joined_units.received_raw = {
-        'cidr': '192.168.0.0/24'
-    }
-    provider.relations[1].application_name = 'app1'
-    provider.relations[1].joined_units.received_raw = {
-        'cidr': '192.168.1.0/24'
-    }
-    assert provider.get_config() == {'cidr': '192.168.0.0/24'}
-    assert provider.get_config('app0') == {'cidr': '192.168.0.0/24'}
-    assert provider.get_config('app1') == {'cidr': '192.168.1.0/24'}
+    provider = provides.CNIPluginProvider("cni", [1, 2])
+    provider.relations[0].application_name = "app0"
+    provider.relations[0].joined_units.received_raw = {"cidr": "192.168.0.0/24"}
+    provider.relations[1].application_name = "app1"
+    provider.relations[1].joined_units.received_raw = {"cidr": "192.168.1.0/24"}
+    assert provider.get_config() == {"cidr": "192.168.0.0/24"}
+    assert provider.get_config("app0") == {"cidr": "192.168.0.0/24"}
+    assert provider.get_config("app1") == {"cidr": "192.168.1.0/24"}
 
 
 def test_config_available():
-    provider = provides.CNIPluginProvider()
-    provider.relations = [MagicMock(), MagicMock()]
-    provider.relations[0].application_name = 'app0'
-    provider.relations[1].application_name = 'app1'
+    provider = provides.CNIPluginProvider("cni", [1, 2])
+    provider.relations[0].application_name = "app0"
+    provider.relations[1].application_name = "app1"
 
     def set_base_data():
         charmhelpers.core.hookenv.goal_state.return_value = {
-            'relations': {
-                'cni': {
-                    'app0': 'foo',
-                    'app1': 'foo',
+            "relations": {
+                "cni": {
+                    "app0": "foo",
+                    "app1": "foo",
                 }
             }
         }
         provider.relations[0].joined_units.received_raw = {
-            'cidr': '192.168.0.0/24',
-            'cni-conf-file': '10-app0.conflist'
+            "cidr": "192.168.0.0/24",
+            "cni-conf-file": "10-app0.conflist",
         }
         provider.relations[1].joined_units.received_raw = {
-            'cidr': '192.168.1.0/24',
-            'cni-conf-file': '10-app1.conflist'
+            "cidr": "192.168.1.0/24",
+            "cni-conf-file": "10-app1.conflist",
         }
 
     # if there are no cni relations, then config is not available yet
     set_base_data()
     goal_state = charmhelpers.core.hookenv.goal_state()
-    goal_state['relations'] = {}
+    goal_state["relations"] = {}
     assert not provider.config_available()
 
     # if there are no related cni apps, then config is not available yet
     set_base_data()
     goal_state = charmhelpers.core.hookenv.goal_state()
-    goal_state['relations']['cni'] = {}
+    goal_state["relations"]["cni"] = {}
     assert not provider.config_available()
 
     # if goal_state shows an app that's missing from relations, then config
     # is not available yet
     set_base_data()
     goal_state = charmhelpers.core.hookenv.goal_state()
-    goal_state['relations']['cni']['app2'] = 'foo'
+    goal_state["relations"]["cni"]["app2"] = "foo"
     assert not provider.config_available()
 
     # if cidr is missing from any related app, then config is not available
     for i in range(2):
         set_base_data()
-        del provider.relations[i].joined_units.received_raw['cidr']
+        del provider.relations[i].joined_units.received_raw["cidr"]
         assert not provider.config_available()
 
     # if cni-conf-file is missing from any related app, then config is not
     # available
     for i in range(2):
         set_base_data()
-        del provider.relations[i].joined_units.received_raw['cni-conf-file']
+        del provider.relations[i].joined_units.received_raw["cni-conf-file"]
         assert not provider.config_available()
 
     # otherwise, config is available

--- a/tests/test_provides.py
+++ b/tests/test_provides.py
@@ -92,3 +92,13 @@ def test_config_available():
     # otherwise, config is available
     set_base_data()
     assert provider.config_available()
+
+
+def test_notify_kubeconfig_changed():
+    charmhelpers.core.host.file_hash.return_value = "hash"
+    provider = provides.CNIPluginProvider("cni", [1, 2])
+    provider.notify_kubeconfig_changed()
+    assert [r.to_publish_raw for r in provider.relations] == [
+        {"kubeconfig-hash": "hash"},
+        {"kubeconfig-hash": "hash"},
+    ]

--- a/tests/test_requires.py
+++ b/tests/test_requires.py
@@ -1,20 +1,30 @@
-from unittest.mock import MagicMock
+from charms.reactive import clear_flag, is_flag_set
 
 import requires
 
 
 def test_get_config():
-    client = requires.CNIPluginClient("test")
+    client = requires.CNIPluginClient("cni", [1])
     config = {"is_master": False}
     client.all_joined_units.received_raw = config
     assert client.get_config() == config
 
 
 def test_set_config():
-    client = requires.CNIPluginClient("test")
-    client.relations = [MagicMock(), MagicMock()]
+    client = requires.CNIPluginClient("cni", [1])
     client.set_config("192.168.0.0/24", "10-test.conflist")
-    for relation in client.relations:
-        relation.to_publish_raw.update.assert_called_once_with(
-            {"cidr": "192.168.0.0/24", "cni-conf-file": "10-test.conflist"}
-        )
+    assert client.relations[0].to_publish_raw == {
+        "cidr": "192.168.0.0/24",
+        "cni-conf-file": "10-test.conflist",
+    }
+
+
+def test_manage_flags():
+    client = requires.CNIPluginClient("cni", [1])
+    client.all_joined_units.received_raw["kubeconfig-hash"] = "hash"
+    client.manage_flags()
+    assert is_flag_set("cni.kubeconfig-changed")
+
+    clear_flag("cni.kubeconfig-changed")
+    client.manage_flags()
+    assert not is_flag_set("cni.kubeconfig-changed")

--- a/tests/test_requires.py
+++ b/tests/test_requires.py
@@ -4,20 +4,17 @@ import requires
 
 
 def test_get_config():
-    client = requires.CNIPluginClient()
-    config = {
-        'is_master': False
-    }
+    client = requires.CNIPluginClient("test")
+    config = {"is_master": False}
     client.all_joined_units.received_raw = config
     assert client.get_config() == config
 
 
 def test_set_config():
-    client = requires.CNIPluginClient()
+    client = requires.CNIPluginClient("test")
     client.relations = [MagicMock(), MagicMock()]
-    client.set_config('192.168.0.0/24', '10-test.conflist')
+    client.set_config("192.168.0.0/24", "10-test.conflist")
     for relation in client.relations:
-        relation.to_publish_raw.update.assert_called_once_with({
-            'cidr': '192.168.0.0/24',
-            'cni-conf-file': '10-test.conflist'
-        })
+        relation.to_publish_raw.update.assert_called_once_with(
+            {"cidr": "192.168.0.0/24", "cni-conf-file": "10-test.conflist"}
+        )

--- a/tests/test_requires.py
+++ b/tests/test_requires.py
@@ -6,8 +6,7 @@ import requires
 def test_get_config():
     client = requires.CNIPluginClient()
     config = {
-        'is_master': False,
-        'kubeconfig_path': '/path/to/kubeconfig'
+        'is_master': False
     }
     client.all_joined_units.received_raw = config
     assert client.get_config() == config

--- a/tests/test_requires.py
+++ b/tests/test_requires.py
@@ -23,8 +23,10 @@ def test_manage_flags():
     client = requires.CNIPluginClient("cni", [1])
     client.all_joined_units.received_raw["kubeconfig-hash"] = "hash"
     client.manage_flags()
-    assert is_flag_set("cni.kubeconfig-changed")
+    assert is_flag_set("cni.kubeconfig.available")
+    assert is_flag_set("cni.kubeconfig.changed")
 
-    clear_flag("cni.kubeconfig-changed")
+    clear_flag("cni.kubeconfig.changed")
     client.manage_flags()
-    assert not is_flag_set("cni.kubeconfig-changed")
+    assert is_flag_set("cni.kubeconfig.available")
+    assert not is_flag_set("cni.kubeconfig.changed")

--- a/tox.ini
+++ b/tox.ini
@@ -2,22 +2,28 @@
 skipsdist = True
 envlist = lint,py3
 
-[tox:travis]
-3.5: lint,py3
-3.6: lint,py3
-3.7: lint,py3
-
 [testenv]
 basepython = python3
 setenv =
     PYTHONPATH={toxinidir}:{toxinidir}/lib
+    PYTHONBREAKPOINT=ipdb.set_trace
 deps =
     pyyaml
     pytest
     flake8
+    black
     ipdb
+    # Temporarily use branch until PR #16 is merged and released
+    https://github.com/juju-solutions/charms.unit_test/archive/refs/heads/johnsca/endpoint-base.zip#egg=charms.unit_test
+    charms.unit_test
 commands = pytest --tb native -s {posargs}
 
 [testenv:lint]
 envdir = {toxworkdir}/py3
-commands = flake8 --max-line-length=88 {toxinidir}
+commands =
+    flake8 {toxinidir}
+    black --check {toxinidir}
+
+[flake8]
+exclude=.tox
+max-line-length = 88

--- a/tox.ini
+++ b/tox.ini
@@ -13,8 +13,6 @@ deps =
     flake8
     black
     ipdb
-    # Temporarily use branch until PR #16 is merged and released
-    https://github.com/juju-solutions/charms.unit_test/archive/refs/heads/johnsca/endpoint-base.zip#egg=charms.unit_test
     charms.unit_test
 commands = pytest --tb native -s {posargs}
 


### PR DESCRIPTION
https://bugs.launchpad.net/charm-calico/+bug/1920034

The Calico charm needs to be informed when the Kubernetes API has changed. It gets that information via kubeconfig files on the local system, so, add a new kubeconfig-hash field to notify.

Removed kubeconfig_path to avoid confusion. It was pointing to a local kubeconfig with a Kubelet user (which never really made sense for CNI anyway) and is not the admin kubeconfig that the CNI subordinates need to know about. Subordinates can get the admin kubeconfig path via `kubernetes_common.kubeclientconfig_path` instead.