### PR TITLE
Remove is_master from relation data

### DIFF
--- a/provides.py
+++ b/provides.py
@@ -4,7 +4,7 @@ from charmhelpers.core import hookenv
 from charmhelpers.core.host import file_hash
 from charms.layer.kubernetes_common import kubeclientconfig_path
 from charms.reactive import Endpoint
-from charms.reactive import toggle_flag, is_flag_set, clear_flag, set_flag
+from charms.reactive import toggle_flag, clear_flag
 
 
 class CNIPluginProvider(Endpoint):
@@ -13,15 +13,7 @@ class CNIPluginProvider(Endpoint):
         toggle_flag(
             self.expand_name("{endpoint_name}.available"), self.config_available()
         )
-        if is_flag_set(self.expand_name("endpoint.{endpoint_name}.changed")):
-            clear_flag(self.expand_name("{endpoint_name}.configured"))
-            clear_flag(self.expand_name("endpoint.{endpoint_name}.changed"))
-
-    def set_config(self, is_master):
-        """Relays a dict of kubernetes configuration information."""
-        for relation in self.relations:
-            relation.to_publish_raw.update({"is_master": is_master})
-        set_flag(self.expand_name("{endpoint_name}.configured"))
+        clear_flag(self.expand_name("endpoint.{endpoint_name}.changed"))
 
     def config_available(self):
         """Ensures all config from the CNI plugin is available."""

--- a/requires.py
+++ b/requires.py
@@ -23,24 +23,12 @@ class CNIPluginClient(Endpoint):
         """Indicate the relation is connected, and if the relation data is
         set it is also available."""
         set_state(self.expand_name("{endpoint_name}.connected"))
-        config = self.get_config()
-        if config["is_master"] == "True":
-            set_state(self.expand_name("{endpoint_name}.is-master"))
-            set_state(self.expand_name("{endpoint_name}.configured"))
-        elif config["is_master"] == "False":
-            set_state(self.expand_name("{endpoint_name}.is-worker"))
-            set_state(self.expand_name("{endpoint_name}.configured"))
-        else:
-            remove_state(self.expand_name("{endpoint_name}.configured"))
         remove_state(self.expand_name("endpoint.{endpoint_name}.changed"))
 
     @when_not("endpoint.{endpoint_name}.joined")
     def broken(self):
         """Indicate the relation is no longer available and not connected."""
         remove_state(self.expand_name("{endpoint_name}.connected"))
-        remove_state(self.expand_name("{endpoint_name}.is-master"))
-        remove_state(self.expand_name("{endpoint_name}.is-worker"))
-        remove_state(self.expand_name("{endpoint_name}.configured"))
 
     def get_config(self):
         """Get the kubernetes configuration information."""

--- a/tests/test_provides.py
+++ b/tests/test_provides.py
@@ -1,17 +1,5 @@
 import charmhelpers
-from charms.reactive import is_flag_set
-
 import provides
-
-
-def test_set_config():
-    provider = provides.CNIPluginProvider("cni", [1, 2])
-    provider.set_config(False)
-    assert [r.to_publish_raw for r in provider.relations] == [
-        {"is_master": False},
-        {"is_master": False},
-    ]
-    assert is_flag_set("cni.configured")
 
 
 def test_get_configs():

--- a/tests/test_requires.py
+++ b/tests/test_requires.py
@@ -5,7 +5,7 @@ import requires
 
 def test_get_config():
     client = requires.CNIPluginClient("cni", [1])
-    config = {"is_master": False}
+    config = {"kubeconfig-hash": "hash"}
     client.all_joined_units.received_raw = config
     assert client.get_config() == config
 


### PR DESCRIPTION
CNI subordinate behavior will no longer differ between masters and workers. As such, `is_master` can be removed from the CNI relation, and since there is no other config to set, `set_config` can be removed too.

This is needed to support adding kubelet to kubernetes-master.